### PR TITLE
Update Failsafe.java

### DIFF
--- a/farmhelper-mod/src/main/java/com/jelly/farmhelper/features/Failsafe.java
+++ b/farmhelper-mod/src/main/java/com/jelly/farmhelper/features/Failsafe.java
@@ -96,6 +96,9 @@ public class Failsafe {
                 if (cooldown.passed() && jacobWait.passed() && !AutoCookie.isEnabled() && !AutoPot.isEnabled()) {
                     LogUtils.webhookLog("Not at island - teleporting back");
                     mc.thePlayer.sendChatMessage(wasInGarden ? "/warp garden" : "/is");
+                    updateKeys(false, false, false, false, false, true, false)
+                    Thread.sleep(1000);
+                    updateKeys(false, false, false, false, false, false, false)
                     cooldown.schedule(5000);
                 }
                 return;


### PR DESCRIPTION
Not sure if Thread.sleep() is how you would want to do it but this should make it so that warping back to the island, you shift for a second to stop flying for the people with mushroom soup fly time and cookie buff fly (bug where it puts you in fly mode when you warp to island/garden)