### PR TITLE
Fixing proxy connection error

### DIFF
--- a/farmhelper-mod/src/main/java/com/jelly/farmhelper/network/proxy/ProxyManager.java
+++ b/farmhelper-mod/src/main/java/com/jelly/farmhelper/network/proxy/ProxyManager.java
@@ -45,7 +45,7 @@ public class ProxyManager {
             try {
                 isTesting = true;
                 final boolean[] success = {false};
-                NetworkManager manager = NetworkManager.createNetworkManagerAndConnect(InetAddress.getByName("us.mineplex.com"), 25565, false);
+                NetworkManager manager = NetworkManager.createNetworkManagerAndConnect(InetAddress.getByName("tm.mc-complex.com"), 25565, false);
                 manager.setNetHandler(new INetHandlerStatusClient() {
                     public void onDisconnect(IChatComponent reason) {}
 
@@ -64,7 +64,7 @@ public class ProxyManager {
 
                 // Doesn't seem to work without this timeout??
                 Thread.sleep(1000);
-                manager.sendPacket(new C00Handshake(47, "us.mineplex.com", 25565, EnumConnectionState.STATUS));
+                manager.sendPacket(new C00Handshake(47, "tm.mc-complex.com", 25565, EnumConnectionState.STATUS));
                 manager.sendPacket(new C00PacketServerQuery());
                 Thread.sleep(4000);
                 if (!success[0]) {


### PR DESCRIPTION
Switch to another server (I recommend tm.mc-complex.com) as the Mineplex server is currently closed, resulting in a proxy connection error. This should resolve the issue and allow you to play normally.