### PR TITLE
Automatically send a Discord Webhook Message on Mod Update!

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,3 +28,42 @@ jobs:
         with:
           name: build-artifacts
           path: build
+      - name: Verify build artifacts
+        run: |
+          ls -R build
+      - name: Fetch latest commit details
+        id: latest_commit
+        run: |
+          COMMIT_API_RESPONSE=$(curl -s -H "Authorization: token ${{ secrets.GH_TOKEN }}" "https://api.github.com/repos/JellyLabScripts/FarmHelper/commits?per_page=1")
+          COMMIT_SHA=$(echo "$COMMIT_API_RESPONSE" | jq -r '.[0].sha')
+          COMMIT_MESSAGE=$(echo "$COMMIT_API_RESPONSE" | jq -r '.[0].commit.message')
+          echo "::set-output name=commit_sha::$COMMIT_SHA"
+          echo "::set-output name=commit_message::$COMMIT_MESSAGE"
+
+      - name: Send embed message with timestamp and footer
+        run: |
+          TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)
+          LONG_DATE=$(date -u +"%A, %B %-d, %Y at %T")
+          curl -X POST -H "Content-Type: application/json" \
+            -d '{
+                  "embeds": [
+                    {
+                      "title": "FarmHelper has updated!",
+                      "description": "To view the full list of changes head over to the GitHub \u200B[commits](https://github.com/JellyLabScripts/FarmHelper/commits/master).",
+                      "color": 65280,
+                      "timestamp": "'"$TIMESTAMP"'",
+                      "footer": {
+                        "text": "Latest commit: '"$LONG_DATE"'\n'"${{ steps.latest_commit.outputs.commit_message }}"' ('"${{ steps.latest_commit.outputs.commit_sha }}"')"
+                      }
+                    }
+                  ]
+                }' \
+            ${{ secrets.DISCORD_WEBHOOK_URL }}
+      - name: Send build artifacts to Discord webhook
+        run: |
+          cd build
+          for file in *.jar; do
+            curl -X POST -H "Content-Type: multipart/form-data" \
+              -F "file=@$file" \
+              ${{ secrets.DISCORD_WEBHOOK_URL }}
+          done


### PR DESCRIPTION
This cool thing basically sends the latest mods from actions to a webhook, but I added cool formatting (kinda) Makes use of secret keys so that your private data is not exposed. (API Authentication, Discord Webhooks)

Quick Rundown of the Script:

Two Repository Secrets are used, GH_TOKEN and DISCORD_WEBHOOK_URL, the URL is for sending everything to a webhook, without exposing the webhook of course. You will need to create these secrets or github actions will just error out.

A simple curl request is made to first send the fancy embed, then to send the files.
After I made this initial draft I decided to show commit details inside the embed, to do this I needed to contact github's API and I needed a API Token to contact it, so I made another secret called GH_TOKEN and that fetches the latest commit details to put in the footer of the embed. Now I do not know how secrets work in repositories with multiple collaborators, as far as I am aware, they cant see your token and you can make specific tokens... That's why I am going to paste a gist with the gradle.yml without the fancy commit information.

This is a draft although a fully functioning draft so I am just creating a normal pr, I am going to add more cooler things later!
**Timestamps may also be broken**

With the fancy Commit Information: 

![image](https://github.com/JellyLabScripts/FarmHelper/assets/77439254/7ad0a9d7-724a-49ab-bb3a-008df49a9cc7)

I forgot to take a screenshot of the embed without the fancy commit information but literally just remove the information.
[Here](https://gist.github.com/sideload1754/2fde8cf1fe2a9549c4b6f6d6616901b9) is the gist for the gradle.yml without use of the GitHub API to fetch commit information!



