### PR TITLE
Automatically set mod version from build.gradle.kts

### DIFF
--- a/farmhelper-mod/src/main/java/com/jelly/farmhelper/FarmHelper.java
+++ b/farmhelper-mod/src/main/java/com/jelly/farmhelper/FarmHelper.java
@@ -36,10 +36,11 @@ import java.util.jar.Manifest;
 public class FarmHelper {
     public static final String MODID = "farmhelper";
     public static final String NAME = "Farm Helper";
+    // Version gets automatically set. If you wish to change it, change it in the build.gradle.kts file
     public static final String VERSION = "%%VERSION%%";
 
     // the actual mod version from gradle properties, should match with VERSION
-    public static String MODVERSION = "-1";
+    public static String MODVERSION = VERSION;
     public static String BOTVERSION = "-1";
     public static int tickCount = 0;
     public static TickTask ticktask;
@@ -115,7 +116,6 @@ public class FarmHelper {
                 "/META-INF/MANIFEST.MF";
         Manifest manifest = new Manifest(new URL(manifestPath).openStream());
         Attributes attr = manifest.getMainAttributes();
-        MODVERSION = attr.getValue("modversion");
         BOTVERSION = attr.getValue("botversion");
         Display.setTitle(FarmHelper.NAME + " " + MODVERSION + " | Bing Chilling");
     }

--- a/farmhelper-mod/src/main/java/com/jelly/farmhelper/FarmHelper.java
+++ b/farmhelper-mod/src/main/java/com/jelly/farmhelper/FarmHelper.java
@@ -36,7 +36,7 @@ import java.util.jar.Manifest;
 public class FarmHelper {
     public static final String MODID = "farmhelper";
     public static final String NAME = "Farm Helper";
-    public static final String VERSION = "4.5.0-PRE";
+    public static final String VERSION = "%%VERSION%%";
 
     // the actual mod version from gradle properties, should match with VERSION
     public static String MODVERSION = "-1";


### PR DESCRIPTION
Someone reverted my change that the mod version gets automatically set by blossom >:( So I added it back and added a notice to change the version in build.gradle.kts instead of in the code.