### PR TITLE
Update GitHub Actions Checkout Action and Repository Badges

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
 
       # Step 2: Check out the source code of the repository
       - name: Checkout project sources
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v4.0.0
 
       # Step 3: Set up Gradle and build the project
       - name: Setup Gradle and build

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div style="text-align: center;">
+<p align="center">
   <a href="https://github.com/JellyLabScripts/FarmHelper/graphs/contributors" alt="Contributors">
     <img src="https://img.shields.io/github/contributors/JellyLabScripts/FarmHelper" />
   </a>
@@ -6,12 +6,12 @@
     <img alt="release" src="https://img.shields.io/github/v/release/JellyLabScripts/FarmHelper?color=00A6A6" />
   </a>
   <a href="https://github.com/JellyLabScripts/FarmHelper/releases" target="_blank">
-    <img alt="downloads" src="https://img.shields.io/github/downloads/JellyLabScripts/FarmHelper/total?color=E24E1B" />
+    <img alt="downloads" src="https://img.shields.io/github/downloads/JellyLabScripts/FarmHelper/total?color=5D5179" />
   </a>
   <a href="https://discord.gg/6mSHC2Xd9y" target="_blank">
     <img alt="discord" src="https://img.shields.io/discord/450878205294018560?color=677DB7&label=discord" />
   </a>
-</div>
+</p>
 
 <br />
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
-[![Contributors][contributors-shield]][contributors-url]
-[![Forks][forks-shield]][forks-url]
-[![Stargazers][stars-shield]][stars-url]
-[![Issues][issues-shield]][issues-url]
-![Downloads][downloads-shield]
+<div style="text-align: center;">
+  <a href="https://github.com/JellyLabScripts/FarmHelper/graphs/contributors" alt="Contributors">
+    <img src="https://img.shields.io/github/contributors/JellyLabScripts/FarmHelper" />
+  </a>
+  <a href="https://github.com/JellyLabScripts/FarmHelper/releases" target="_blank">
+    <img alt="release" src="https://img.shields.io/github/v/release/JellyLabScripts/FarmHelper?color=00A6A6" />
+  </a>
+  <a href="https://github.com/JellyLabScripts/FarmHelper/releases" target="_blank">
+    <img alt="downloads" src="https://img.shields.io/github/downloads/JellyLabScripts/FarmHelper/total?color=E24E1B" />
+  </a>
+  <a href="https://discord.gg/6mSHC2Xd9y" target="_blank">
+    <img alt="discord" src="https://img.shields.io/discord/450878205294018560?color=677DB7&label=discord" />
+  </a>
+</div>
 
 <br />
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 Imagine not having to stare at your computer for 12 hours a day just to press the A and D keys. Imagine, being able to skip all the repetitive processes of farming and do other things simultaneously. Farm Helper is a highly customizable skyblock quality of life (QOL) mod that automates boring farming processes, freeing up your time for other activities.
 
-Revolutionizing the farming meta of Hypixel skyblock, Farm Helper has already been downloaded over 20,000 times. Start your QOL journey by joining the Jellylab community!
+Revolutionizing the farming meta of Hypixel skyblock, Farm Helper has already been downloaded over 30,000 times. Start your QOL journey by joining the Jellylab community!
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 <p align="center">
   <a href="https://github.com/JellyLabScripts/FarmHelper/graphs/contributors" alt="Contributors">
-    <img src="https://img.shields.io/github/contributors/JellyLabScripts/FarmHelper" />
+    <img src="https://img.shields.io/github/contributors/JellyLabScripts/FarmHelper?color=blue" />
   </a>
   <a href="https://github.com/JellyLabScripts/FarmHelper/releases" target="_blank">
-    <img alt="release" src="https://img.shields.io/github/v/release/JellyLabScripts/FarmHelper?color=00A6A6" />
+    <img alt="release" src="https://img.shields.io/github/v/release/JellyLabScripts/FarmHelper?color=green" />
   </a>
   <a href="https://github.com/JellyLabScripts/FarmHelper/releases" target="_blank">
-    <img alt="downloads" src="https://img.shields.io/github/downloads/JellyLabScripts/FarmHelper/total?color=5D5179" />
+    <img alt="downloads" src="https://img.shields.io/github/downloads/JellyLabScripts/FarmHelper/total?color=purple" />
   </a>
   <a href="https://discord.gg/6mSHC2Xd9y" target="_blank">
-    <img alt="discord" src="https://img.shields.io/discord/450878205294018560?color=677DB7&label=discord" />
+    <img alt="discord" src="https://img.shields.io/discord/450878205294018560?color=orange&label=discord" />
   </a>
 </p>
 


### PR DESCRIPTION
**Changes:**

1. Updated GitHub Actions checkout action from `v3.6.0` to `v4.0.0`
2. Enhanced repository badge presentation and linked badges to relevant resources (contributors, releases, downloads, Discord)