### PR TITLE
fix(RenderUtils): implicit cast from 'double' to 'float'

### DIFF
--- a/src/main/java/com/jelly/farmhelperv2/util/RenderUtils.java
+++ b/src/main/java/com/jelly/farmhelperv2/util/RenderUtils.java
@@ -143,7 +143,7 @@ public class RenderUtils {
 
         double distance = Math.sqrt(renderPosX * renderPosX + renderPosY * renderPosY + renderPosZ * renderPosZ);
         double multiplier = Math.max(distance / 150f, 0.1f);
-        lScale *= 0.45f * multiplier;
+        lScale *= (float) (0.45f * multiplier);
 
         float xMultiplier = Minecraft.getMinecraft().gameSettings.thirdPersonView == 2 ? -1 : 1;
 


### PR DESCRIPTION
adding the expression `(float)` to warn the compiler that the result of the expression is of type `float` and avoid possible data loss in this expression.