### PR TITLE
fix(cleanSB): removing removing extra complexion

### DIFF
--- a/src/main/java/com/jelly/farmhelperv2/util/ScoreboardUtils.java
+++ b/src/main/java/com/jelly/farmhelperv2/util/ScoreboardUtils.java
@@ -71,7 +71,7 @@ public class ScoreboardUtils {
         StringBuilder cleaned = new StringBuilder();
 
         for (char c : StringUtils.stripControlCodes(scoreboard).toCharArray()) {
-            if (c > 20 && c < 127) {
+            if (c >= 32 && c < 127) {
                 cleaned.append(c);
             }
         }

--- a/src/main/java/com/jelly/farmhelperv2/util/ScoreboardUtils.java
+++ b/src/main/java/com/jelly/farmhelperv2/util/ScoreboardUtils.java
@@ -68,11 +68,10 @@ public class ScoreboardUtils {
     }
 
     public static String cleanSB(String scoreboard) {
-        char[] nvString = StringUtils.stripControlCodes(scoreboard).toCharArray();
         StringBuilder cleaned = new StringBuilder();
 
-        for (char c : nvString) {
-            if ((int) c > 20 && (int) c < 127) {
+        for (char c : StringUtils.stripControlCodes(scoreboard).toCharArray()) {
+            if (c >= 20 && c <= 127) {
                 cleaned.append(c);
             }
         }

--- a/src/main/java/com/jelly/farmhelperv2/util/ScoreboardUtils.java
+++ b/src/main/java/com/jelly/farmhelperv2/util/ScoreboardUtils.java
@@ -71,7 +71,7 @@ public class ScoreboardUtils {
         StringBuilder cleaned = new StringBuilder();
 
         for (char c : StringUtils.stripControlCodes(scoreboard).toCharArray()) {
-            if (c >= 20 && c <= 127) {
+            if (c > 20 && c < 127) {
                 cleaned.append(c);
             }
         }


### PR DESCRIPTION
This is an optional "enhancement" and should have no impact on time performance. However, it was aimed at reducing complexity in the code, to facilitate readability and conciseness.

* I've removed the unnecessary creation of an nvString character array. You can work directly with `StringUtils.stripControlCodes(scoreboard).toCharArray()`.
* I've simplified the condition in the `for` loop to check if the character is in the desired range.