### PR TITLE
fix(onChatReceived#L597): NumberFormatException

### DIFF
--- a/src/main/java/com/jelly/farmhelperv2/feature/impl/AutoSprayonator.java
+++ b/src/main/java/com/jelly/farmhelperv2/feature/impl/AutoSprayonator.java
@@ -596,10 +596,8 @@ public class AutoSprayonator implements IFeature {
 
         if (!message.startsWith("SPRAYONATOR!")) return;
 
-        String[] messageParts = message.split(" ");
-        if (messageParts.length >= 6) {
-            String plotNumberString = messageParts[5];
-
+        if (message.contains("sprayed")) {
+            String plotNumberString = message.split(" ")[5];
             if (plotNumberString.matches("\\d+")) {
                 int plotNumber = Integer.parseInt(plotNumberString);
                 PlotData data = new PlotData(plotNumber, sprayItem.getItemName(), TimeUnit.MINUTES.toMillis(30));

--- a/src/main/java/com/jelly/farmhelperv2/feature/impl/AutoSprayonator.java
+++ b/src/main/java/com/jelly/farmhelperv2/feature/impl/AutoSprayonator.java
@@ -585,18 +585,24 @@ public class AutoSprayonator implements IFeature {
 
     @SubscribeEvent
     public void onChatReceived(ClientChatReceivedEvent e) {
-        if (mc.thePlayer == null || mc.theWorld == null) return;
+        if (mc.thePlayer == null || mc.theWorld == null || e.message == null) return;
 
         String message = StringUtils.stripControlCodes(e.message.getUnformattedText());
-        if (message.contains("sprayed with that item recently")) {
-            sprayState = AUTO_SPRAYONATOR_STATE.CHECK_PLOTS;
-        }
-        if (!StringUtils.stripControlCodes(e.message.getUnformattedText()).startsWith("SPRAYONATOR!")) return;
-        if (message.contains("sprayed")) {
-            String plotNumber = e.message.getUnformattedText().split(" ")[5];
-            PlotData data = new PlotData(Integer.parseInt(plotNumber), sprayItem.getItemName(), TimeUnit.MINUTES.toMillis(30));
-            sprayonatorPlotStates.put(Integer.parseInt(plotNumber), data);
-            sprayState = AUTO_SPRAYONATOR_STATE.WAITING_FOR_PLOT;
+
+        if (message.contains("sprayed with that item recently")) sprayState = AUTO_SPRAYONATOR_STATE.CHECK_PLOTS;
+
+        if (!message.startsWith("SPRAYONATOR!")) return;
+
+        String[] messageParts = message.split(" ");
+        if (messageParts.length >= 6) {
+            String plotNumberString = messageParts[5];
+
+            if (plotNumberString.matches("\\d+")) {
+                int plotNumber = Integer.parseInt(plotNumberString);
+                PlotData data = new PlotData(plotNumber, sprayItem.getItemName(), TimeUnit.MINUTES.toMillis(30));
+                sprayonatorPlotStates.put(plotNumber, data);
+                sprayState = AUTO_SPRAYONATOR_STATE.WAITING_FOR_PLOT;
+            }
         }
     }
 

--- a/src/main/java/com/jelly/farmhelperv2/feature/impl/AutoSprayonator.java
+++ b/src/main/java/com/jelly/farmhelperv2/feature/impl/AutoSprayonator.java
@@ -597,12 +597,15 @@ public class AutoSprayonator implements IFeature {
         if (!message.startsWith("SPRAYONATOR!")) return;
 
         if (message.contains("sprayed")) {
-            String plotNumberString = message.split(" ")[5];
-            if (plotNumberString.matches("\\d+")) {
-                int plotNumber = Integer.parseInt(plotNumberString);
-                PlotData data = new PlotData(plotNumber, sprayItem.getItemName(), TimeUnit.MINUTES.toMillis(30));
-                sprayonatorPlotStates.put(plotNumber, data);
-                sprayState = AUTO_SPRAYONATOR_STATE.WAITING_FOR_PLOT;
+            String[] messageParts = message.split(" ");
+            if (messageParts.length >= 6) {
+                String plotNumberString = messageParts[5];
+                if (plotNumberString.matches("\\d+")) {
+                    int plotNumber = Integer.parseInt(plotNumberString);
+                    PlotData data = new PlotData(plotNumber, sprayItem.getItemName(), TimeUnit.MINUTES.toMillis(30));
+                    sprayonatorPlotStates.put(plotNumber, data);
+                    sprayState = AUTO_SPRAYONATOR_STATE.WAITING_FOR_PLOT;
+                }
             }
         }
     }

--- a/src/main/java/com/jelly/farmhelperv2/feature/impl/AutoSprayonator.java
+++ b/src/main/java/com/jelly/farmhelperv2/feature/impl/AutoSprayonator.java
@@ -589,7 +589,10 @@ public class AutoSprayonator implements IFeature {
 
         String message = StringUtils.stripControlCodes(e.message.getUnformattedText());
 
-        if (message.contains("sprayed with that item recently")) sprayState = AUTO_SPRAYONATOR_STATE.CHECK_PLOTS;
+        if (message.contains("sprayed with that item recently")) {
+            sprayState = AUTO_SPRAYONATOR_STATE.CHECK_PLOTS;
+            return; // Avoids additional processing if the condition is met
+        }
 
         if (!message.startsWith("SPRAYONATOR!")) return;
 


### PR DESCRIPTION
The code is trying to convert the sixth element of the string divided by space (index 5) into an integer using `Integer.parseInt(plotNumber)`. The error occurs when the string `"Carrot2"` is passed to `Integer.parseInt`, as it is not a valid representation of an integer.

To fix this, I've incorporated a regular expression check directly into onChatReceived to check that the string only contains digits.