### PR TITLE
Feature: Support for cocoa bean farms with trapdoors

### DIFF
--- a/src/main/java/com/jelly/farmhelperv2/config/FarmHelperConfig.java
+++ b/src/main/java/com/jelly/farmhelperv2/config/FarmHelperConfig.java
@@ -92,6 +92,7 @@ public class FarmHelperConfig extends Config {
                     "S Shape - Cactus", // 5
                     "S Shape - Cactus SunTzu Black Cat", // 6
                     "S Shape - Cocoa Beans", // 7
+                    "S Shape - Cocoa Beans (With Trapdoors)", // 7
                     "S Shape - Cocoa Beans (Left/Right)", // 8
                     "S Shape - Mushroom (45°)", // 9
                     "S Shape - Mushroom (30° with rotations)", // 10
@@ -2288,6 +2289,7 @@ public class FarmHelperConfig extends Config {
         S_CACTUS,
         S_CACTUS_SUNTZU,
         S_COCOA_BEANS,
+        S_COCOA_BEANS_TRAPDOORS,
         S_COCOA_BEANS_LEFT_RIGHT,
         S_MUSHROOM,
         S_MUSHROOM_ROTATE,

--- a/src/main/java/com/jelly/farmhelperv2/handler/MacroHandler.java
+++ b/src/main/java/com/jelly/farmhelperv2/handler/MacroHandler.java
@@ -100,6 +100,7 @@ public class MacroHandler {
             case S_SUGAR_CANE:
                 return Macros.S_SHAPE_SUGARCANE_MACRO.getMacro();
             case S_COCOA_BEANS:
+            case S_COCOA_BEANS_TRAPDOORS:
                 return Macros.S_SHAPE_COCOA_BEAN_MACRO.getMacro();
             case S_MUSHROOM:
                 return Macros.S_SHAPE_MUSHROOM_MACRO.getMacro();

--- a/src/main/java/com/jelly/farmhelperv2/macro/impl/SShapeCocoaBeanMacro.java
+++ b/src/main/java/com/jelly/farmhelperv2/macro/impl/SShapeCocoaBeanMacro.java
@@ -173,14 +173,26 @@ public class SShapeCocoaBeanMacro extends AbstractMacro {
             double z = mc.thePlayer.getPositionVector().zCoord % 1;
             float yaw = AngleUtils.getClosest(mc.thePlayer.rotationYaw);
             yaw = (yaw % 360 + 360) % 360;
-            if (yaw == 0) {
-                return (x > -0.9 && x < -0.35) || (x < 0.65 && x > 0.1);
-            } else if (yaw == 90) {
-                return (z > -0.9 && z < -0.35) || (z < 0.65 && z > 0.1);
-            } else if (yaw == 180) {
-                return (x > -0.65 && x < -0.1) || (x < 0.9 && x > 0.35);
-            } else if (yaw == 270) {
-                return (z > -0.65 && z < -0.1) || (z < 0.9 && z > 0.35);
+            if (FarmHelperConfig.getMacro() == FarmHelperConfig.MacroEnum.S_COCOA_BEANS_TRAPDOORS) {
+                if (yaw == 0) {
+                    return (x > -0.9 && x < -0.5) || (x < 0.5 && x > 0.1);
+                } else if (yaw == 90) {
+                    return (z > -0.9 && z < -0.5) || (z < 0.5 && z > 0.1);
+                } else if (yaw == 180) {
+                    return (x > -0.5 && x < -0.1) || (x < 0.9 && x > 0.5);
+                } else if (yaw == 270) {
+                    return (z > -0.5 && z < -0.1) || (z < 0.9 && z > 0.5);
+                }
+            } else {
+                if (yaw == 0) {
+                    return (x > -0.9 && x < -0.35) || (x < 0.65 && x > 0.1);
+                } else if (yaw == 90) {
+                    return (z > -0.9 && z < -0.35) || (z < 0.65 && z > 0.1);
+                } else if (yaw == 180) {
+                    return (x > -0.65 && x < -0.1) || (x < 0.9 && x > 0.35);
+                } else if (yaw == 270) {
+                    return (z > -0.65 && z < -0.1) || (z < 0.9 && z > 0.35);
+                }
             }
         }
         return false;


### PR DESCRIPTION
This PR adds support for cocoa bean farms with a full row of trap doors (a new macro type of Cocoa (With Trapdoors))
A beneficiary of this PR would be users who built MelonKingDE's no TP mega farm ( https://www.youtube.com/watch?v=rcP0XHZGI2A )
This PR has been tested