### PR TITLE
Fixed Pest Exchange not respecting "Trigger before contest starts (in minutes)"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ baseGroup=com.jelly.farmhelperv2
 mcVersion=1.8.9
 modid=farmhelperv2
 modName=FarmHelper
-version=2.7.4-pre1
+version=2.7.4-pre2
 shouldRelease=true

--- a/src/main/java/com/jelly/farmhelperv2/feature/impl/AutoPestExchange.java
+++ b/src/main/java/com/jelly/farmhelperv2/feature/impl/AutoPestExchange.java
@@ -167,12 +167,24 @@ public class AutoPestExchange implements IFeature {
             LogUtils.sendWarning("[Auto Pest Exchange] Pest Hunter bonus is active or unknown, skipping...");
             return false;
         }
-        if (!manual && GameStateHandler.getInstance().inJacobContest() && !FarmHelperConfig.autoPestExchangeIgnoreJacobsContest) {
+        if (!manual && !GameStateHandler.getInstance().inJacobContest() && !FarmHelperConfig.autoPestExchangeIgnoreJacobsContest) {
+            LogUtils.sendDebug("[Auto Pest Exchange] Checking when Jacob's contest starts...");
             for (String line : TablistUtils.getTabList()) {
-                Matcher matcher = GameStateHandler.getInstance().jacobsRemainingTimePattern.matcher(line);
-                if (matcher.find()) {
-                    String minutes = matcher.group(1);
-                    if (Integer.parseInt(minutes) > FarmHelperConfig.autoPestExchangeTriggerBeforeContestStarts) {
+                Matcher matcher = GameStateHandler.getInstance().jacobsStartsInTimePattern.matcher(line);
+                if (matcher.find() && matcher.groupCount() >= 1) {
+                    float minutes = 0f;
+                    if (line.endsWith("m")) {
+                        minutes = Integer.parseInt(matcher.group(1));
+                    } else if (line.endsWith("s")) {
+                        if (matcher.groupCount() >= 2) {
+                            minutes = Integer.parseInt(matcher.group(1));
+                            minutes += Integer.parseInt(matcher.group(2)) / 60f;
+                        } else {
+                            minutes = Integer.parseInt(matcher.group(1)) / 60f;
+                        }
+                    }
+                    LogUtils.sendDebug("[Auto Pest Exchange] Jacob's contest is starting in " + minutes + " minutes...");
+                    if (minutes > FarmHelperConfig.autoPestExchangeTriggerBeforeContestStarts) {
                         LogUtils.sendDebug("[Auto Pest Exchange] Jacob's contest is starting in " + minutes + " minutes, skipping...");
                         return false;
                     }

--- a/src/main/java/com/jelly/farmhelperv2/handler/GameStateHandler.java
+++ b/src/main/java/com/jelly/farmhelperv2/handler/GameStateHandler.java
@@ -44,7 +44,7 @@ public class GameStateHandler {
     @Getter
     private final Clock jacobContestLeftClock = new Clock();
     public final Pattern jacobsRemainingTimePattern = Pattern.compile("([0-9]|[1-2][0-9])m([0-9]|[1-5][0-9])s");
-    public final Pattern jacobsStartsInTimePattern = Pattern.compile("Starts In: ([1-2]?[0-9])?m ?([1-5]?[0-9])?s?");
+    public final Pattern jacobsStartsInTimePattern = Pattern.compile("Starts In: ([1-3]?[0-9])?m ?([1-5]?[0-9])?s?");
     private final Pattern serverClosingPattern = Pattern.compile("Server closing: (?<minutes>\\d+):(?<seconds>\\d+) .*");
     private final Pattern pestsFromVacuumPattern = Pattern.compile("Vacuum Bag: (\\d+) Pest(s)?");
     @Getter

--- a/src/main/java/com/jelly/farmhelperv2/handler/GameStateHandler.java
+++ b/src/main/java/com/jelly/farmhelperv2/handler/GameStateHandler.java
@@ -44,6 +44,7 @@ public class GameStateHandler {
     @Getter
     private final Clock jacobContestLeftClock = new Clock();
     public final Pattern jacobsRemainingTimePattern = Pattern.compile("([0-9]|[1-2][0-9])m([0-9]|[1-5][0-9])s");
+    public final Pattern jacobsStartsInTimePattern = Pattern.compile("Starts In: ([1-2]?[0-9])?m ?([1-5]?[0-9])?s?");
     private final Pattern serverClosingPattern = Pattern.compile("Server closing: (?<minutes>\\d+):(?<seconds>\\d+) .*");
     private final Pattern pestsFromVacuumPattern = Pattern.compile("Vacuum Bag: (\\d+) Pest(s)?");
     @Getter


### PR DESCRIPTION
This fixes auto pest exchange starting every warp regardless of the next jacob contest
This PR has been tested