### PR TITLE
Add Usage Stats HUD

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ baseGroup=com.jelly.farmhelperv2
 mcVersion=1.8.9
 modid=farmhelperv2
 modName=FarmHelper
-version=2.9.3
+version=2.9.4-pre2
 shouldRelease=true

--- a/src/main/java/com/jelly/farmhelperv2/config/FarmHelperConfig.java
+++ b/src/main/java/com/jelly/farmhelperv2/config/FarmHelperConfig.java
@@ -23,6 +23,7 @@ import com.jelly.farmhelperv2.handler.MacroHandler;
 import com.jelly.farmhelperv2.hud.DebugHUD;
 import com.jelly.farmhelperv2.hud.ProfitCalculatorHUD;
 import com.jelly.farmhelperv2.hud.StatusHUD;
+import com.jelly.farmhelperv2.hud.UsageStatsHUD;
 import com.jelly.farmhelperv2.util.BlockUtils;
 import com.jelly.farmhelperv2.util.LogUtils;
 import com.jelly.farmhelperv2.util.PlayerUtils;
@@ -2148,6 +2149,49 @@ public class FarmHelperConfig extends Config {
             name = "Profit Calculator HUD - Visual Settings", category = HUD, subcategory = " "
     )
     public static ProfitCalculatorHUD profitHUD = new ProfitCalculatorHUD();
+    @Switch(
+            name      = "Show FH Usage Stats Title",
+            category  = HUD,
+            subcategory = "Usage Stats"
+    )
+    public static boolean showStatsTitle = true;
+    @Switch(
+            name      = "Show 24-hour total",
+            category  = HUD,
+            subcategory = "Usage Stats"
+    )
+    public static boolean showStats24H = true;
+    @Switch(
+            name       = "Show 7-day total",
+            category   = HUD,
+            subcategory = "Usage Stats"
+    )
+    public static boolean showStats7D = false;
+    @Switch(
+            name       = "Show 30-day total",
+            category   = HUD,
+            subcategory = "Usage Stats"
+    )
+    public static boolean showStats30D = false;
+    @Switch(
+            name      = "Show lifetime total",
+            category  = HUD,
+            subcategory = "Usage Stats"
+    )
+    public static boolean showStatsLifetime = true;
+    @Switch(
+            name      = "Colour-code 24-hour total",
+            description = "Green < 3.5 h, 3.5 h < Orange < 7 h, Red ≥ 7 h",
+            category  = HUD,
+            subcategory = "Usage Stats"
+    )
+    public static boolean colourCode24H = true;
+    @HUD(
+            name = "Usage Stats HUD - Visual Settings",
+            category = HUD,
+            subcategory = "Usage Stats"
+    )
+    public static UsageStatsHUD UsageStatsHUD = new UsageStatsHUD();
     //</editor-fold>
 
     //<editor-fold desc="DEBUG">

--- a/src/main/java/com/jelly/farmhelperv2/config/FarmHelperConfig.java
+++ b/src/main/java/com/jelly/farmhelperv2/config/FarmHelperConfig.java
@@ -2163,11 +2163,12 @@ public class FarmHelperConfig extends Config {
     )
     public static ProfitCalculatorHUD profitHUD = new ProfitCalculatorHUD();
     @Switch(
-            name      = "Show FH Usage Stats Title",
+            name      = "Colour-code 24-hour total",
+            description = "Green < 3.5 h, 3.5 h < Orange < 7 h, Red ≥ 7 h",
             category  = HUD,
             subcategory = "Usage Stats"
     )
-    public static boolean showStatsTitle = true;
+    public static boolean colourCode24H = true;
     @Switch(
             name      = "Show 24-hour total",
             category  = HUD,
@@ -2181,6 +2182,20 @@ public class FarmHelperConfig extends Config {
     )
     public static boolean showStats7D = false;
     @Switch(
+            name       = "Enable Long Term Data Storage",
+            category   = HUD,
+            subcategory = "Usage Stats"
+    )
+    public static boolean longTermUserStats = false;
+    @Info(
+            text = "Enabling long term storage of user stats could potentially lead to large files (< 1mb), which may cause lag, in time, on slow systems",
+            type = InfoType.WARNING,
+            category = HUD,
+            subcategory = "Usage Stats",
+            size = 2
+    )
+    public static boolean usageStatsInfo;
+    @Switch(
             name       = "Show 30-day total",
             category   = HUD,
             subcategory = "Usage Stats"
@@ -2193,12 +2208,11 @@ public class FarmHelperConfig extends Config {
     )
     public static boolean showStatsLifetime = true;
     @Switch(
-            name      = "Colour-code 24-hour total",
-            description = "Green < 3.5 h, 3.5 h < Orange < 7 h, Red ≥ 7 h",
+            name      = "Show FH Usage Stats Title",
             category  = HUD,
             subcategory = "Usage Stats"
     )
-    public static boolean colourCode24H = true;
+    public static boolean showStatsTitle = false;
     @HUD(
             name = "Usage Stats HUD - Visual Settings",
             category = HUD,
@@ -2480,6 +2494,9 @@ public class FarmHelperConfig extends Config {
         this.addDependency("rotationTimeRandomnessDuringJacob", "customRotationDelaysDuringJacob");
 
         this.addDependency("leaveTime", "leaveTimer");
+
+        this.addDependency("showStats30D", "longTermUserStats");
+        this.addDependency("showStatsLifetime", "longTermUserStats");
 
         this.hideIf("shownWelcomeGUI", () -> true);
 

--- a/src/main/java/com/jelly/farmhelperv2/feature/FeatureManager.java
+++ b/src/main/java/com/jelly/farmhelperv2/feature/FeatureManager.java
@@ -49,6 +49,7 @@ public class FeatureManager {
                 Scheduler.getInstance(),
                 UngrabMouse.getInstance(),
                 VisitorsMacro.getInstance(),
+                UsageStatsTracker.getInstance(),
                 PiPMode.getInstance()
         );
         features.addAll(featuresList);

--- a/src/main/java/com/jelly/farmhelperv2/feature/impl/BanInfoWS.java
+++ b/src/main/java/com/jelly/farmhelperv2/feature/impl/BanInfoWS.java
@@ -472,7 +472,6 @@ public class BanInfoWS implements IFeature {
     public long getLongestSessionLast7D() {
         long sevenDaysAgo = System.currentTimeMillis() - 604800000L; // 7 days in milliseconds
         JsonArray jsonArray = readJsonArrayFromFile();
-        JsonArray updatedJsonArray = new JsonArray();
         long longestSessionLength = 0L;
 
         for (JsonElement element : jsonArray) {
@@ -483,11 +482,9 @@ public class BanInfoWS implements IFeature {
                 if (sessionLength > longestSessionLength) {
                     longestSessionLength = sessionLength;
                 }
-                updatedJsonArray.add(session);
             }
         }
 
-        writeJsonArrayToFile(updatedJsonArray); // Optimize by writing only if needed
         return longestSessionLength;
     }
 

--- a/src/main/java/com/jelly/farmhelperv2/feature/impl/UsageStatsTracker.java
+++ b/src/main/java/com/jelly/farmhelperv2/feature/impl/UsageStatsTracker.java
@@ -2,6 +2,7 @@ package com.jelly.farmhelperv2.feature.impl;
 
 import com.google.gson.*;
 import com.jelly.farmhelperv2.feature.IFeature;
+import com.jelly.farmhelperv2.util.LogUtils;
 import net.minecraft.client.Minecraft;
 
 import java.io.*;
@@ -109,7 +110,10 @@ public class UsageStatsTracker implements IFeature {
              InputStreamReader isr = new InputStreamReader(gzis, StandardCharsets.UTF_8)) {
             JsonElement el = new JsonParser().parse(isr);
             return el.isJsonArray() ? el.getAsJsonArray() : new JsonArray();
-        } catch (Exception e) { e.printStackTrace(); }
+        } catch (Exception e) {
+            LogUtils.sendDebug("Error Reading Usage Stats Array");
+//            e.printStackTrace();
+        }
         return new JsonArray();
     }
 }

--- a/src/main/java/com/jelly/farmhelperv2/feature/impl/UsageStatsTracker.java
+++ b/src/main/java/com/jelly/farmhelperv2/feature/impl/UsageStatsTracker.java
@@ -1,0 +1,115 @@
+package com.jelly.farmhelperv2.feature.impl;
+
+import com.google.gson.*;
+import com.jelly.farmhelperv2.feature.IFeature;
+import net.minecraft.client.Minecraft;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.time.*;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPInputStream;
+
+import static com.jelly.farmhelperv2.feature.impl.BanInfoWS.fileNamePrefix;
+import static com.jelly.farmhelperv2.feature.impl.BanInfoWS.statsDirectory;
+
+
+public class UsageStatsTracker implements IFeature {
+    private static UsageStatsTracker instance;
+    public  static UsageStatsTracker getInstance() {
+        return instance == null ? (instance = new UsageStatsTracker()) : instance;
+    }
+
+    private long baseTodayMillis = 0;
+    private long baseTotalMillis = 0;
+    private LocalDate todayDate = LocalDate.now();
+    private long sessionMillis = 0;
+    private long lastTickMillis = System.currentTimeMillis();
+    private boolean running = false;
+
+    private UsageStatsTracker() { loadFromFile(); }
+
+    public String getTodayString() {
+        return fmt(baseTodayMillis + sessionMillis);
+    }
+    public String getTotalString() {
+        return fmt(baseTotalMillis + sessionMillis);
+    }
+
+    public long  getTodayMillis() { return baseTodayMillis + sessionMillis; }
+
+    private long rollingMillis(int days) {
+        long cutoff = System.currentTimeMillis() - days * 86_400_000L;
+        long sum = 0;
+        for (JsonElement e : readArray()) {
+            JsonObject o = e.getAsJsonObject();
+            if (o.get("timestamp").getAsLong() >= cutoff)
+                sum += o.get("timeMacroing").getAsLong();
+        }
+        return sum + sessionMillis;
+    }
+
+    public long get7dMillis() { return rollingMillis(7);  }
+    public long get30dMillis() { return rollingMillis(30); }
+    public String get7dString() { return fmt(get7dMillis()); }
+    public String get30dString() { return fmt(get30dMillis()); }
+
+    @Override public String  getName() { return "User Stats Tracker"; }
+    @Override public boolean isRunning() { return running; }
+    @Override public boolean shouldPauseMacroExecution() { return false; }
+    @Override public boolean shouldStartAtMacroStart() { return false; }
+    @Override public boolean isToggled() { return true;  }
+    @Override public boolean shouldCheckForFailsafes() { return false; }
+    @Override public void resetStatesAfterMacroDisabled() {}
+    @Override public void start() { running = true;  lastTickMillis = System.currentTimeMillis(); }
+    @Override public void resume() { start(); }
+    @Override public void stop() { running = false ;}
+
+    public void tick(boolean macroRunning) {
+        long now = System.currentTimeMillis();
+        long delta = now - lastTickMillis;
+        lastTickMillis = now;
+        if (!todayDate.equals(LocalDate.now())) {
+            todayDate      = LocalDate.now();
+            baseTodayMillis = 0;
+        }
+        if (macroRunning && delta > 0 && delta < 5000) {
+            sessionMillis += delta;
+        }
+    }
+
+    private void loadFromFile() {
+        JsonArray arr = readArray();
+        LocalDate today = LocalDate.now();
+        for (JsonElement e : arr) {
+            JsonObject o = e.getAsJsonObject();
+            long ms = o.get("timeMacroing").getAsLong();
+            baseTotalMillis += ms;
+            long ts = o.get("timestamp").getAsLong();
+            LocalDate d = Instant.ofEpochMilli(ts).atZone(ZoneId.systemDefault()).toLocalDate();
+            if (d.equals(today)) baseTodayMillis += ms;
+        }
+    }
+
+    private String fmt(long ms) {
+        long h = TimeUnit.MILLISECONDS.toHours(ms);
+        long m = TimeUnit.MILLISECONDS.toMinutes(ms) % 60;
+        return String.format("%dh %02dm", h, m);
+    }
+
+    private File statsFile() {
+        String uuid = Minecraft.getMinecraft().getSession().getPlayerID().replace("-", "");
+        return new File(statsDirectory, fileNamePrefix + uuid + ".dat");
+    }
+
+    private JsonArray readArray() {
+        File f = statsFile();
+        if (!f.exists()) return new JsonArray();
+        try (GZIPInputStream gzis = new GZIPInputStream(new FileInputStream(f));
+             InputStreamReader isr = new InputStreamReader(gzis, StandardCharsets.UTF_8)) {
+            JsonElement el = new JsonParser().parse(isr);
+            return el.isJsonArray() ? el.getAsJsonArray() : new JsonArray();
+        } catch (Exception e) { e.printStackTrace(); }
+        return new JsonArray();
+    }
+}

--- a/src/main/java/com/jelly/farmhelperv2/handler/MacroHandler.java
+++ b/src/main/java/com/jelly/farmhelperv2/handler/MacroHandler.java
@@ -321,6 +321,7 @@ public class MacroHandler {
             if (!cm.isEnabledAndNoFeature()) return;
             cm.onTick();
         });
+        UsageStatsTracker.getInstance().tick(!isCurrentMacroPaused());
     }
 
     @SubscribeEvent

--- a/src/main/java/com/jelly/farmhelperv2/hud/UsageStatsHUD.java
+++ b/src/main/java/com/jelly/farmhelperv2/hud/UsageStatsHUD.java
@@ -35,7 +35,7 @@ public class UsageStatsHUD extends TextHud {
             lines.add("7 day:  §a" + UsageStatsTracker.getInstance().get7dString());
         }
         if (FarmHelperConfig.showStats30D) {
-            lines.add("30 day: §a" + UsageStatsTracker.getInstance().get30dString());
+            lines.add("30 day:  §a" + UsageStatsTracker.getInstance().get30dString());
         }
         if (FarmHelperConfig.showStatsLifetime) {
             lines.add("lifetime: §a" + UsageStatsTracker.getInstance().getTotalString());

--- a/src/main/java/com/jelly/farmhelperv2/hud/UsageStatsHUD.java
+++ b/src/main/java/com/jelly/farmhelperv2/hud/UsageStatsHUD.java
@@ -1,0 +1,54 @@
+package com.jelly.farmhelperv2.hud;
+
+import cc.polyfrost.oneconfig.config.core.OneColor;
+import cc.polyfrost.oneconfig.hud.TextHud;
+import com.jelly.farmhelperv2.config.FarmHelperConfig;
+import com.jelly.farmhelperv2.feature.impl.UsageStatsTracker;
+import com.jelly.farmhelperv2.handler.GameStateHandler;
+
+import java.util.List;
+
+public class UsageStatsHUD extends TextHud {
+
+    public UsageStatsHUD() {
+        super(false, 1f, 10f, 0.9f, true, true,
+                4, 5, 5, new OneColor(0,0,0,150),
+                false, 2, new OneColor(0,0,0,127));
+    }
+
+    @Override
+    protected void getLines(List<String> lines, boolean example) {
+        if (FarmHelperConfig.showStatsTitle) {
+            lines.add("§lFH Usage Stats");
+        }
+        if (FarmHelperConfig.showStats24H) {
+            String colour = "";
+            if (FarmHelperConfig.colourCode24H) {
+                double hrs = UsageStatsTracker.getInstance().getTodayMillis() / 3_600_000.0;
+                if (hrs < 3.5)        colour = "§a";
+                else if (hrs < 7.0)   colour = "§6";
+                else                  colour = "§c";
+            }
+            lines.add("24 hour:  " + colour + UsageStatsTracker.getInstance().getTodayString());
+        }
+        if (FarmHelperConfig.showStats7D) {
+            lines.add("7 day:    §a" + UsageStatsTracker.getInstance().get7dString());
+        }
+        if (FarmHelperConfig.showStats30D) {
+            lines.add("30 day:   §a" + UsageStatsTracker.getInstance().get30dString());
+        }
+        if (FarmHelperConfig.showStatsLifetime) {
+            lines.add("lifetime:  §a" + UsageStatsTracker.getInstance().getTotalString());
+        }
+        if (!FarmHelperConfig.showStatsTitle &&!FarmHelperConfig.showStats24H && !FarmHelperConfig.showStats7D && !FarmHelperConfig.showStats30D && !FarmHelperConfig.showStatsLifetime) {
+            lines.add("§cEnable usage stats in the HUD config menu");
+        }
+    }
+
+    @Override
+    protected boolean shouldShow() {
+        return super.shouldShow()
+                && !FarmHelperConfig.streamerMode
+                && GameStateHandler.getInstance().inGarden();
+    }
+}

--- a/src/main/java/com/jelly/farmhelperv2/hud/UsageStatsHUD.java
+++ b/src/main/java/com/jelly/farmhelperv2/hud/UsageStatsHUD.java
@@ -32,13 +32,13 @@ public class UsageStatsHUD extends TextHud {
             lines.add("24 hour:  " + colour + UsageStatsTracker.getInstance().getTodayString());
         }
         if (FarmHelperConfig.showStats7D) {
-            lines.add("7 day:    §a" + UsageStatsTracker.getInstance().get7dString());
+            lines.add("7 day:  §a" + UsageStatsTracker.getInstance().get7dString());
         }
         if (FarmHelperConfig.showStats30D) {
-            lines.add("30 day:   §a" + UsageStatsTracker.getInstance().get30dString());
+            lines.add("30 day: §a" + UsageStatsTracker.getInstance().get30dString());
         }
         if (FarmHelperConfig.showStatsLifetime) {
-            lines.add("lifetime:  §a" + UsageStatsTracker.getInstance().getTotalString());
+            lines.add("lifetime: §a" + UsageStatsTracker.getInstance().getTotalString());
         }
         if (!FarmHelperConfig.showStatsTitle &&!FarmHelperConfig.showStats24H && !FarmHelperConfig.showStats7D && !FarmHelperConfig.showStats30D && !FarmHelperConfig.showStatsLifetime) {
             lines.add("§cEnable usage stats in the HUD config menu");

--- a/src/main/java/com/jelly/farmhelperv2/hud/UsageStatsHUD.java
+++ b/src/main/java/com/jelly/farmhelperv2/hud/UsageStatsHUD.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class UsageStatsHUD extends TextHud {
 
     public UsageStatsHUD() {
-        super(false, 1f, 10f, 0.9f, true, true,
+        super(true, 1f, 10f, 0.9f, true, true,
                 4, 5, 5, new OneColor(0,0,0,150),
                 false, 2, new OneColor(0,0,0,127));
     }


### PR DESCRIPTION
changed [BanInfoWS.java](https://github.com/JellyLabScripts/FarmHelper/compare/master...Jookly123:FarmHelper:persistant-user-stats?expand=1#diff-f5df78c9cc80e1d72be98b589f07b5b8a90708c8cf7f0cf21f36d925e54f3e9c) so that it no longer deletes user farming data after 7 days --> stores log of farming data in /farmhelper/fh_stats_uuid.dat 

added a small HUD element that has toggleable elements in oneconfig HUD section.

added [UsageStatsTracker.java](https://github.com/JellyLabScripts/FarmHelper/compare/master...Jookly123:FarmHelper:persistant-user-stats?expand=1#diff-db2ed7b292f5df18ab50bc9fcc2115e662cf55c3d16b8797ae5612e95ec4e9db) which handles most of the logic for displaying total farming times: 24hrs, 7days, 30days, lifetime.