### PR TITLE
Banned user discord notif

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ baseGroup=com.jelly.farmhelperv2
 mcVersion=1.8.9
 modid=farmhelperv2
 modName=FarmHelper
-version=2.9.4-pre2
+version=2.9.4-pre3
 shouldRelease=true

--- a/src/main/java/com/jelly/farmhelperv2/config/FarmHelperConfig.java
+++ b/src/main/java/com/jelly/farmhelperv2/config/FarmHelperConfig.java
@@ -1413,6 +1413,11 @@ public class FarmHelperConfig extends Config {
             description = "Sends messages when the macro has been enabled or disabled"
     )
     public static boolean sendMacroEnableDisableLogs = true;
+    @Switch(
+            name = "Send FH ban logs", category = DISCORD_INTEGRATION, subcategory = "Discord Webhook",
+            description = "Sends message when a FH user gets banned (Like in game chat)"
+    )
+    public static boolean sendFHBanLogs = true;
     @Text(
             name = "WebHook URL", category = DISCORD_INTEGRATION, subcategory = "Discord Webhook",
             description = "The URL to use for the webhook",

--- a/src/main/java/com/jelly/farmhelperv2/config/FarmHelperConfig.java
+++ b/src/main/java/com/jelly/farmhelperv2/config/FarmHelperConfig.java
@@ -1417,7 +1417,7 @@ public class FarmHelperConfig extends Config {
             name = "Send FH ban logs", category = DISCORD_INTEGRATION, subcategory = "Discord Webhook",
             description = "Sends message when a FH user gets banned (Like in game chat)"
     )
-    public static boolean sendFHBanLogs = true;
+    public static boolean sendFHBanLogs = false;
     @Text(
             name = "WebHook URL", category = DISCORD_INTEGRATION, subcategory = "Discord Webhook",
             description = "The URL to use for the webhook",

--- a/src/main/java/com/jelly/farmhelperv2/feature/impl/BanInfoWS.java
+++ b/src/main/java/com/jelly/farmhelperv2/feature/impl/BanInfoWS.java
@@ -640,12 +640,14 @@ public class BanInfoWS implements IFeature {
                         String crop = jsonObject.get("crop").getAsString().toLowerCase().replace("_", " ");
                         long longestSession7D = jsonObject.get("longestSession7D").getAsLong();
                         String lastFailsafe = jsonObject.get("lastFailsafe").getAsString();
-                        LogUtils.sendWarning("User §c" + username + "§e got banned for " + days + " days"
+                        String warningMessage = ("User §c" + username + "§e got banned for " + days + " days"
                                 + (macroEnabled ? " while " + (fastBreak ? "§c§nfastbreaking§r§e " : "farming ") + crop + "." : ".")
                                 + "\n§ePossible reason: §c" + reason + "§e."
                                 + "\n§eLongest session in the last 7 days: §c" + LogUtils.formatTime(longestSession7D)
                                 + (!lastFailsafe.isEmpty() ? "\n§eLast failsafe: §c" + lastFailsafe : ""));
+                        LogUtils.sendWarning(warningMessage);
                         // LogUtils.sendNotification("Farm Helper", "User " + username + " got banned for " + days + " days");
+                        if (FarmHelperConfig.sendFHBanLogs && FarmHelperConfig.enableWebHook) LogUtils.webhookLog(warningMessage);
                         break;
                     }
                 }

--- a/src/main/java/com/jelly/farmhelperv2/feature/impl/BanInfoWS.java
+++ b/src/main/java/com/jelly/farmhelperv2/feature/impl/BanInfoWS.java
@@ -36,6 +36,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -647,7 +648,11 @@ public class BanInfoWS implements IFeature {
                                 + (!lastFailsafe.isEmpty() ? "\n§eLast failsafe: §c" + lastFailsafe : ""));
                         LogUtils.sendWarning(warningMessage);
                         // LogUtils.sendNotification("Farm Helper", "User " + username + " got banned for " + days + " days");
-                        if (FarmHelperConfig.sendFHBanLogs && FarmHelperConfig.enableWebHook) LogUtils.webhookLog(warningMessage);
+                        if (FarmHelperConfig.sendFHBanLogs && FarmHelperConfig.enableWebHook) {
+                            Pattern MC_COLOUR = Pattern.compile("§[0-9A-FK-ORa-fk-or]");
+                            String cleanString = MC_COLOUR.matcher(warningMessage).replaceAll("").replace("\n", "\\n");
+                            LogUtils.webhookLog(cleanString);
+                        }
                         break;
                     }
                 }

--- a/src/main/java/com/jelly/farmhelperv2/feature/impl/BanInfoWS.java
+++ b/src/main/java/com/jelly/farmhelperv2/feature/impl/BanInfoWS.java
@@ -651,7 +651,7 @@ public class BanInfoWS implements IFeature {
                         if (FarmHelperConfig.sendFHBanLogs && FarmHelperConfig.enableWebHook) {
                             Pattern MC_COLOUR = Pattern.compile("§[0-9A-FK-ORa-fk-or]");
                             String cleanString = MC_COLOUR.matcher(warningMessage).replaceAll("").replace("\n", "\\n");
-                            LogUtils.webhookLog(cleanString);
+                            LogUtils.FHBanLogsWebhook(cleanString);
                         }
                         break;
                     }

--- a/src/main/java/com/jelly/farmhelperv2/util/LogUtils.java
+++ b/src/main/java/com/jelly/farmhelperv2/util/LogUtils.java
@@ -181,6 +181,28 @@ public class LogUtils {
         sendWebhook(webhook);
     }
 
+    @SafeVarargs
+    public static void FHBanLogsWebhook(String message, Tuple<String, String>... fields) {
+        if (!FarmHelperConfig.enableWebHook) return;
+        if (!FarmHelperConfig.sendLogs) return;
+        if (!FarmHelperConfig.sendFHBanLogs) return;
+
+        DiscordWebhook webhook = new DiscordWebhook(FarmHelperConfig.webHookURL.replace(" ", "").replace("\n", "").trim());
+        webhook.setUsername("Jelly - Farm Helper [User Bans Log]");
+        webhook.setAvatarUrl("https://cdn.discordapp.com/attachments/1152966451406327858/1160577992876109884/icon.png");
+        String randomColor = String.format("#%06x", (int) (Math.random() * 0xFFFFFF));
+        DiscordWebhook.EmbedObject embedObject = new DiscordWebhook.EmbedObject()
+                .setDescription("### " + message)
+                .setColor(Color.decode(randomColor))
+                .setFooter("Farm Helper Webhook Status", "https://cdn.discordapp.com/attachments/861700235890130986/1144673641951395982/icon.png");
+        for (Tuple<String, String> field : fields) {
+            embedObject.addField(field.getFirst(), field.getSecond(), false);
+        }
+        retries = 0;
+        webhook.addEmbed(embedObject);
+        sendWebhook(webhook);
+    }
+
     private static void sendWebhook(DiscordWebhook webhook) {
         Multithreading.schedule(() -> {
             try {

--- a/src/main/java/com/jelly/farmhelperv2/util/LogUtils.java
+++ b/src/main/java/com/jelly/farmhelperv2/util/LogUtils.java
@@ -188,7 +188,7 @@ public class LogUtils {
         if (!FarmHelperConfig.sendFHBanLogs) return;
 
         DiscordWebhook webhook = new DiscordWebhook(FarmHelperConfig.webHookURL.replace(" ", "").replace("\n", "").trim());
-        webhook.setUsername("Jelly - Farm Helper [User Bans Log]");
+        webhook.setUsername("Jelly - User Bans Log");
         webhook.setAvatarUrl("https://cdn.discordapp.com/attachments/1152966451406327858/1160577992876109884/icon.png");
         String randomColor = String.format("#%06x", (int) (Math.random() * 0xFFFFFF));
         DiscordWebhook.EmbedObject embedObject = new DiscordWebhook.EmbedObject()


### PR DESCRIPTION
Added option to send ban messages of other players through discord, (just like game chat):
![{78F720A0-0942-49AF-85E3-8EFD9792C6F7}](https://github.com/user-attachments/assets/5dda8365-ed99-423f-82af-c5281971a0fe)

the config option is disabled by default for people running multiple instances of FH.