### PR TITLE
Fixed Autobazaar retrying to buy indefinitely when the inventory is full

### DIFF
--- a/src/main/java/com/jelly/farmhelperv2/feature/impl/AutoSprayonator.java
+++ b/src/main/java/com/jelly/farmhelperv2/feature/impl/AutoSprayonator.java
@@ -12,6 +12,7 @@ import com.jelly.farmhelperv2.util.InventoryUtils;
 import com.jelly.farmhelperv2.util.KeyBindUtils;
 import com.jelly.farmhelperv2.util.LogUtils;
 import com.jelly.farmhelperv2.util.helper.Clock;
+import com.jelly.farmhelperv2.util.PlayerUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -201,7 +202,13 @@ public class AutoSprayonator implements IFeature {
         this.swapState(State.WAITING, 5000);
         break;
       case BUYING_MATERIAL:
-        if (this.isTimerRunning()) {
+        if (this.isTimerRunning()) {  
+          break;
+        }
+        if (PlayerUtils.isInventoryFull(mc.thePlayer)) {
+          LogUtils.sendError("AutoBazaar could not buy " + this.getSprayMaterial() + " because inventory is full. Pausing until restart");
+          this.pause = true;
+          this.stop();
           break;
         }
         AutoBazaar.getInstance().buy(this.getSprayMaterial(), FarmHelperConfig.autoSprayonatorAutoBuyAmount);


### PR DESCRIPTION
Fixed a problem where, when the inventory is full and the full-inventory failsafe is bypassed (idk how), AutoSprayonator Autobazaar would keep buying spray material indefinitely. This happened because it couldn't detect the material in the inventory, and continued until the player either ran out of money or an evacuation occurred.

I was unable to replicate how AutoBazaar bypassed the full-inventory failsafe, but I only could reproduce it by setting the failsafe stop delay to the maximum. In that case, AutoBazaar tries to buy spray material before the failsafe stops all actions, even when the inventory is full. The instantly bought spray material is then transferred to the stash, causing Autobazaar to repeat the process indefinitely.

This happened to me once while I was AFK, Autobazaar kept instantly buying spray material until an evacuation occurred, leaving me with 300M worth of plant matter.

This issue is resolved by performing an inventory check before executing AutoSprayonator AutoBazaar, which prevents any actions if the inventory is full.

Let me know if you need logs or clip from the evacuation